### PR TITLE
#466 - Support different AS for `access_token` validation (other then the one processing API call)

### DIFF
--- a/docs/sources/api/index.md
+++ b/docs/sources/api/index.md
@@ -61,6 +61,20 @@ Oxd server is also protected by [Authorization Request Header Field](https://too
 
 The required parameters for `/get-client-token` are `op_host`, `client_id` and `client_secret`.
 
+**Using Different AS for `access_token` validation**
+
+oxd can also be configured to a different Authorization Server (AS) for `access_token` validation other then the one processing API call. Follow below steps to configure another AS to protect APIs calls:
+
+1. Register client (AS1) in oxd using `/register-site`.
+
+1. Register the AS (AS2) to used for protecting APIs using `/register-site` end-point.
+
+1. Generate access token using `/get-client-token` by passing `op_host`, `client_id` and `client_secret` of the registered AS2.
+
+1. In subsequent apis call pass `AuthorizationOxdId: <oxd_id>` HTTP header along with `Authorization: <access_token>` HTTP header. In `AuthorizationOxdId` set `oxd_id` of Authorization Server (AS2) for protecting APIs.
+
+`protect_commands_with_oxd_id` array is to limit oxd_id's that can be send via `AuthorizationOxdId` header. However if this field is missed from configuration then any oxd_id (i.e. AS registered to oxd) can be send using `AuthorizationOxdId` header.
+
 ### Get Access Token by Refresh Token
 
 [API Link](#operations-developers-get-access-token-by-refresh-token)

--- a/docs/sources/api/index.md
+++ b/docs/sources/api/index.md
@@ -63,7 +63,7 @@ The required parameters for `/get-client-token` are `op_host`, `client_id` and `
 
 **Using Different AS for `access_token` validation**
 
-oxd can also be configured to use a different Authorization Server (AS) for `access_token` validation other then the one processing API call. Follow below steps to configure another AS to protect APIs calls:
+oxd can also be configured to use a different Authorization Server (AS) for `access_token` validation other than the one processing API call. Follow below steps to configure another AS to protect APIs calls:
 
 1. Register client (say AS1) in oxd using `/register-site`.
 

--- a/docs/sources/api/index.md
+++ b/docs/sources/api/index.md
@@ -73,7 +73,7 @@ oxd can also be configured to use a different Authorization Server (AS) for `acc
 
 1. In subsequent apis call pass `AuthorizationOxdId: <oxd_id>` HTTP header along with `Authorization: <access_token>` HTTP header. In `AuthorizationOxdId` set `oxd_id` of Authorization Server (AS2) for protecting APIs.
 
-`protect_commands_with_oxd_id` array in `/opt/oxd-server/conf/oxd-server.yml` is to limit oxd_id's that can be send via `AuthorizationOxdId` header. However if this field is missed from configuration then any oxd_id (i.e. AS registered to oxd) can be send using `AuthorizationOxdId` header.
+`protect_commands_with_oxd_id` array in `/opt/oxd-server/conf/oxd-server.yml` is to limit oxd_id's that can be send via `AuthorizationOxdId` header. However if this field is missed from configuration then any oxd_id (i.e. AS registered to oxd) can be used to validate access token.
 
 ### Get Access Token by Refresh Token
 

--- a/docs/sources/api/index.md
+++ b/docs/sources/api/index.md
@@ -65,9 +65,9 @@ The required parameters for `/get-client-token` are `op_host`, `client_id` and `
 
 oxd can also be configured to use a different Authorization Server (AS) for `access_token` validation other then the one processing API call. Follow below steps to configure another AS to protect APIs calls:
 
-1. Register client (AS1) in oxd using `/register-site`.
+1. Register client (say AS1) in oxd using `/register-site`.
 
-1. Register the AS (AS2) to used for protecting APIs using `/register-site` end-point.
+1. Register the AS (say AS2, to protect APIs) using `/register-site` end-point.
 
 1. Generate access token using `/get-client-token` by passing `op_host`, `client_id` and `client_secret` of the registered AS2.
 

--- a/docs/sources/api/index.md
+++ b/docs/sources/api/index.md
@@ -63,7 +63,7 @@ The required parameters for `/get-client-token` are `op_host`, `client_id` and `
 
 **Using Different AS for `access_token` validation**
 
-oxd can also be configured to a different Authorization Server (AS) for `access_token` validation other then the one processing API call. Follow below steps to configure another AS to protect APIs calls:
+oxd can also be configured to use a different Authorization Server (AS) for `access_token` validation other then the one processing API call. Follow below steps to configure another AS to protect APIs calls:
 
 1. Register client (AS1) in oxd using `/register-site`.
 
@@ -73,7 +73,7 @@ oxd can also be configured to a different Authorization Server (AS) for `access_
 
 1. In subsequent apis call pass `AuthorizationOxdId: <oxd_id>` HTTP header along with `Authorization: <access_token>` HTTP header. In `AuthorizationOxdId` set `oxd_id` of Authorization Server (AS2) for protecting APIs.
 
-`protect_commands_with_oxd_id` array is to limit oxd_id's that can be send via `AuthorizationOxdId` header. However if this field is missed from configuration then any oxd_id (i.e. AS registered to oxd) can be send using `AuthorizationOxdId` header.
+`protect_commands_with_oxd_id` array in `/opt/oxd-server/conf/oxd-server.yml` is to limit oxd_id's that can be send via `AuthorizationOxdId` header. However if this field is missed from configuration then any oxd_id (i.e. AS registered to oxd) can be send using `AuthorizationOxdId` header.
 
 ### Get Access Token by Refresh Token
 

--- a/docs/sources/configuration/oxd-configuration/index.md
+++ b/docs/sources/configuration/oxd-configuration/index.md
@@ -34,6 +34,7 @@ uma2_auto_register_claims_gathering_endpoint_as_redirect_uri_of_client: true
 add_client_credentials_grant_type_automatically_during_client_registration: true
 migration_source_folder_path: ''
 allowed_op_hosts: []
+protect_commands_with_oxd_id: []
 storage: h2
 storage_configuration:
   dbFileLocation: /opt/oxd-server/data/oxd_db
@@ -178,6 +179,8 @@ defaultSiteConfig:
 - **migration_source_folder_path:** Migration from previous versions is built into the `oxd-server`. To migrate old JSON files from previous versions, specify the path to folder/directory that contains those JSON files in this property. Those files will be read and imported once (during restart `oxd-server`, will not import them again). If using Windows OS, don't forget to escape the path separator, e.g. `C:\\OXD_OLD\\oxd-server\\conf`
 
 - **allowed_op_hosts:** Array containing a list of the `op_host` urls. oxd can only access the `op_hosts` from this list and all other calls (to IDPs not present in this list ) will be rejected. If the list is empty then oxd is allowed to access any OpenID Connect Provider.
+
+- **protect_commands_with_oxd_id** RP can use different Authorization Servers (AS) to protect oxd API’s with access token. This field contains array of `oxd_ids` of AS registered with oxd which are allowed to protect oxd API’s. Eg: `protect_commands_with_oxd_id: ['<oxd_id1>', '<oxd_id2>', '<oxd_id3>' ...]`. If it is missed from the configuration then any AS registered with oxd can be used for protecting oxd end-points.
 
 - **storage:** This value can be `h2` or `jdbc` or `redis`. 
 

--- a/docs/sources/configuration/oxd-configuration/index.md
+++ b/docs/sources/configuration/oxd-configuration/index.md
@@ -180,7 +180,7 @@ defaultSiteConfig:
 
 - **allowed_op_hosts:** Array containing a list of the `op_host` urls. oxd can only access the `op_hosts` from this list and all other calls (to IDPs not present in this list ) will be rejected. If the list is empty then oxd is allowed to access any OpenID Connect Provider.
 
-- **protect_commands_with_oxd_id** RP can use different Authorization Servers (AS) to protect oxd API’s with access token. This field contains array of `oxd_id` of AS registered with oxd which are allowed to protect oxd API’s. Eg: `protect_commands_with_oxd_id: ['<oxd_id1>', '<oxd_id2>', '<oxd_id3>' ...]`. If it is missed from the configuration then any AS registered with oxd can be used for protecting oxd end-points.
+- **protect_commands_with_oxd_id** RP can use different Authorization Servers (AS) for protecting oxd API’s with access token. This field contains array of `oxd_id` of AS registered with oxd which are allowed to protect oxd API’s. Eg: `protect_commands_with_oxd_id: ['<oxd_id1>', '<oxd_id2>', '<oxd_id3>' ...]`. If it is missed from the configuration then any AS registered with oxd can be used for protecting oxd end-points.
 
 - **storage:** This value can be `h2` or `jdbc` or `redis`. 
 

--- a/docs/sources/configuration/oxd-configuration/index.md
+++ b/docs/sources/configuration/oxd-configuration/index.md
@@ -180,7 +180,7 @@ defaultSiteConfig:
 
 - **allowed_op_hosts:** Array containing a list of the `op_host` urls. oxd can only access the `op_hosts` from this list and all other calls (to IDPs not present in this list ) will be rejected. If the list is empty then oxd is allowed to access any OpenID Connect Provider.
 
-- **protect_commands_with_oxd_id** RP can use different Authorization Servers (AS) to protect oxd API’s with access token. This field contains array of `oxd_ids` of AS registered with oxd which are allowed to protect oxd API’s. Eg: `protect_commands_with_oxd_id: ['<oxd_id1>', '<oxd_id2>', '<oxd_id3>' ...]`. If it is missed from the configuration then any AS registered with oxd can be used for protecting oxd end-points.
+- **protect_commands_with_oxd_id** RP can use different Authorization Servers (AS) to protect oxd API’s with access token. This field contains array of `oxd_id` of AS registered with oxd which are allowed to protect oxd API’s. Eg: `protect_commands_with_oxd_id: ['<oxd_id1>', '<oxd_id2>', '<oxd_id3>' ...]`. If it is missed from the configuration then any AS registered with oxd can be used for protecting oxd end-points.
 
 - **storage:** This value can be `h2` or `jdbc` or `redis`. 
 


### PR DESCRIPTION
#466 - Support different AS for `access_token` validation (other then the one processing API call)
https://github.com/GluuFederation/oxd/issues/466